### PR TITLE
Advanced Interactive Street View: Make "Voted" and "Already Voted" notifications not interactible

### DIFF
--- a/interact_advanced.user.js
+++ b/interact_advanced.user.js
@@ -62,6 +62,10 @@
 			.radio-body {
 				border-bottom-left-radius: 0 !important;
 			}
+
+			.voted {
+				pointer-events: none;
+			}
 		`);
 
 		// Changing this in preparation for the breaking changes in IRF 0.5.0


### PR DESCRIPTION
These last for a little bit after they fade out, and screw with initiating a pan of the streetview frame below them.