### PR TITLE
Advanced Interactive Street View: Don't wait for `handleSetPanoMessage()` to finish before marking updates as unpaused

### DIFF
--- a/aisv/src/aisv/sv/pano.ts
+++ b/aisv/src/aisv/sv/pano.ts
@@ -21,7 +21,7 @@ let updatesPaused = false;
 let updatesPausedManually = false;
 async function pauseUpdates(pause, source) {
     if (!pause && lastSetPanoMessageData) {
-        await handleSetPanoMessage(
+        handleSetPanoMessage(
             lastSetPanoMessageData,
             updatesPausedManually ? 'smooth' : 'instant'
         );


### PR DESCRIPTION
Fixes an issue where the toggle pause button would remain frosted until the whole pano transition went through.